### PR TITLE
Add units to AxisLabel

### DIFF
--- a/src/axis-label.js
+++ b/src/axis-label.js
@@ -22,6 +22,7 @@ const AxisLabel = ({
   bottom,
   children,
   sx,
+  units,
   arrow = true,
   align = 'right',
 }) => {
@@ -38,6 +39,18 @@ const AxisLabel = ({
     right: 'flex-end',
     center: 'center',
   }
+
+  const inner = (
+    <>
+      {children}
+      {units && (
+        <>
+          &nbsp;
+          <Box sx={{ textTransform: 'none', color: 'secondary' }}>{units}</Box>
+        </>
+      )}
+    </>
+  )
 
   return (
     <>
@@ -58,7 +71,7 @@ const AxisLabel = ({
               justifyContent: alignToFlex[align],
             }}
           >
-            {children}
+            {inner}
             {arrow && (
               <>
                 <Arrow
@@ -107,7 +120,7 @@ const AxisLabel = ({
                   justifyContent: alignToFlex[align],
                 }}
               >
-                {children}
+                {inner}
                 {arrow && (
                   <>
                     <Arrow


### PR DESCRIPTION
Adds dedicated prop for `units` on `AxisLabel` to standardize styles. If special styles are needed, customized children can still be provided.

<img width="801" alt="Screen Shot 2021-10-06 at 2 32 35 PM" src="https://user-images.githubusercontent.com/12436887/136286350-59c13f70-e305-49b8-b4d2-40d7cef87b9b.png">
