### PR TITLE
support label alignment

### DIFF
--- a/demo/components/contents.js
+++ b/demo/components/contents.js
@@ -1,4 +1,4 @@
 export const contents = {
-  Basics: ['Axis'],
+  Basics: ['Axis', 'Labels'],
   Charts: ['Scatter', 'Donut', 'Bar', 'StackedBar'],
 }

--- a/demo/pages/axis.md
+++ b/demo/pages/axis.md
@@ -7,9 +7,6 @@ import {
   TickLabels,
   Axis,
   AxisLabel,
-  Plot,
-  Scatter,
-  Circle,
 } from '@carbonplan/charts'
 import { scaleLinear } from 'd3-scale'
 

--- a/demo/pages/donut.md
+++ b/demo/pages/donut.md
@@ -14,4 +14,14 @@ This is a donut chart.
   </Chart>
 </Box>
 
+```jsx
+<Box sx={{ width: '100%', height: '200px' }}>
+  <Chart padding={{ left: 0, bottom: 0 }}>
+    <Plot square>
+      <Donut data={[100, 50, 30]} innerRadius={0.26} color={'purple'} />
+    </Plot>
+  </Chart>
+</Box>
+```
+
 export default ({ children }) => <Section name='donut'>{children}</Section>

--- a/demo/pages/labels.md
+++ b/demo/pages/labels.md
@@ -1,0 +1,99 @@
+import Section from '../components/section'
+import { Box } from 'theme-ui'
+import {
+  Chart,
+  Grid,
+  Ticks,
+  TickLabels,
+  Axis,
+  AxisLabel,
+  Label,
+  Plot,
+  Circle,
+} from '@carbonplan/charts'
+import { scaleLinear } from 'd3-scale'
+
+# Labels
+
+We can add labels to a chart by specifying a location. We're showing a point at the coordinate of each label for clarity.
+
+<Box sx={{ width: '100%', height: '200px', my: [6] }}>
+  <Chart x={[0, 100]} y={[0, 100]} padding={{ left: 60, top: 0 }}>
+    <Grid vertical horizontal />
+    <Ticks left bottom />
+    <TickLabels left bottom />
+    <AxisLabel left>Axis one</AxisLabel>
+    <AxisLabel bottom>Axis two</AxisLabel>
+    <Label x={60} y={40}>
+      This is a label at (60,40)
+    </Label>
+    <Label x={20} y={80}>
+      This is a label at (20,80)
+    </Label>
+    <Plot>
+      <Circle x={20} y={80} size={5} />
+      <Circle x={60} y={40} size={5} />
+    </Plot>
+  </Chart>
+</Box>
+
+The horizontal alignment is controlled with the `align` prop and can be `left` `right` or `center`.
+
+<Box sx={{ width: '100%', height: '200px', my: [6] }}>
+  <Chart x={[0, 100]} y={[0, 100]} padding={{ left: 60, top: 0 }}>
+    <Grid vertical horizontal />
+    <Ticks left bottom />
+    <TickLabels left bottom />
+    <AxisLabel left>Axis one</AxisLabel>
+    <AxisLabel bottom>Axis two</AxisLabel>
+    <Label x={50} y={15} align='right'>
+      This label is right aligned
+    </Label>
+    <Label x={50} y={50} width={50} align='center'>
+      This label is center aligned
+    </Label>
+    <Label x={50} y={85} align='left'>
+      This label is left aligned
+    </Label>
+    <Plot>
+      <Circle x={50} y={15} size={5} />
+      <Circle x={50} y={50} size={5} />
+      <Circle x={50} y={85} size={5} />
+    </Plot>
+  </Chart>
+</Box>
+
+The vertical alignment is controlled with the `verticalAlign` prop and can be `top` `bottom` or `middle`.
+
+<Box sx={{ width: '100%', height: '200px', my: [6] }}>
+  <Chart x={[0, 100]} y={[0, 100]} padding={{ left: 60, top: 0 }}>
+    <Grid vertical horizontal />
+    <Ticks left bottom />
+    <TickLabels left bottom />
+    <AxisLabel left>Axis one</AxisLabel>
+    <AxisLabel bottom>Axis two</AxisLabel>
+    <Label x={50} y={15} align='center' width={50} verticalAlign='top'>
+      This label is top aligned
+    </Label>
+    <Label
+      x={50}
+      y={50}
+      align='center'
+      height={50}
+      width={50}
+      verticalAlign='middle'
+    >
+      This label is middle aligned
+    </Label>
+    <Label x={50} y={85} align='center' width={50} verticalAlign='bottom'>
+      This label is bottom aligned
+    </Label>
+    <Plot>
+      <Circle x={50} y={15} size={5} />
+      <Circle x={50} y={50} size={5} />
+      <Circle x={50} y={85} size={5} />
+    </Plot>
+  </Chart>
+</Box>
+
+export default ({ children }) => <Section name='axis'>{children}</Section>

--- a/demo/pages/scatter.md
+++ b/demo/pages/scatter.md
@@ -36,4 +36,27 @@ This is a scatter chart.
   </Chart>
 </Box>
 
+```jsx
+<Box sx={{ width: '100%', height: '400px' }}>
+  <Chart x={[0, 100]} y={[0, 100]} padding={{ left: 60, top: 50 }}>
+    <Grid vertical horizontal />
+    <Ticks left bottom />
+    <TickLabels left bottom />
+    <AxisLabel left>Variable one</AxisLabel>
+    <AxisLabel bottom>Variable two</AxisLabel>
+    <Plot>
+      <Scatter
+        size={10}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        data={[
+          { x: 100, y: 50 },
+          { x: 0, y: 100 },
+        ]}
+      />
+    </Plot>
+  </Chart>
+</Box>
+```
+
 export default ({ children }) => <Section name='scatter'>{children}</Section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/charts",
-  "version": "2.4.0",
+  "version": "2.5.0-develop.1",
   "description": "themeable reusable responsive web charts",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/src/label.js
+++ b/src/label.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import Point from './point'
 
-const Label = ({ x, y, children, sx }) => {
+const Label = ({ x, y, children, align='left', verticalAlign='top', width, sx }) => {
   return (
-    <Point x={x} y={y}>
+    <Point x={x} y={y} width={width} align={align} verticalAlign={verticalAlign}>
       <Box
         sx={{
           fontFamily: 'mono',
@@ -12,6 +12,7 @@ const Label = ({ x, y, children, sx }) => {
           textTransform: 'uppercase',
           fontSize: [0],
           color: 'secondary',
+          textAlign: align,
           ...sx,
         }}
       >

--- a/src/label.js
+++ b/src/label.js
@@ -2,9 +2,23 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import Point from './point'
 
-const Label = ({ x, y, children, align='left', verticalAlign='top', width, sx }) => {
+const Label = ({
+  x,
+  y,
+  children,
+  align = 'left',
+  verticalAlign = 'top',
+  width,
+  sx,
+}) => {
   return (
-    <Point x={x} y={y} width={width} align={align} verticalAlign={verticalAlign}>
+    <Point
+      x={x}
+      y={y}
+      width={width}
+      align={align}
+      verticalAlign={verticalAlign}
+    >
       <Box
         sx={{
           fontFamily: 'mono',

--- a/src/label.js
+++ b/src/label.js
@@ -2,20 +2,13 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import Point from './point'
 
-const Label = ({
-  x,
-  y,
-  children,
-  align = 'left',
-  verticalAlign = 'top',
-  width,
-  sx,
-}) => {
+const Label = ({ x, y, children, align, verticalAlign, width, height, sx }) => {
   return (
     <Point
       x={x}
       y={y}
       width={width}
+      height={height}
       align={align}
       verticalAlign={verticalAlign}
     >

--- a/src/point.js
+++ b/src/point.js
@@ -1,17 +1,28 @@
 import React from 'react'
 import { useChart } from './chart'
 
-const Point = ({ x, y, children, align='left', verticalAlign='top', width }) => {
+const Point = ({
+  x,
+  y,
+  children,
+  align = 'left',
+  verticalAlign = 'top',
+  width,
+}) => {
   const { x: _x, y: _y, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
 
   let position, verticalPosition
 
   if (!['left', 'right', 'center'].includes(align)) {
-    throw new Error(`'${align}' is not a recognized alignment, must be left, right, or center`)
+    throw new Error(
+      `'${align}' is not a recognized alignment, must be left, right, or center`
+    )
   }
 
   if (!['top', 'bottom'].includes(verticalAlign)) {
-    throw new Error(`'${verticalAlign}' is not a recognized vertical alignment, must be top or bottom`)
+    throw new Error(
+      `'${verticalAlign}' is not a recognized vertical alignment, must be top or bottom`
+    )
   }
 
   if (align === 'center' && !width) {
@@ -26,8 +37,8 @@ const Point = ({ x, y, children, align='left', verticalAlign='top', width }) => 
 
   if (align === 'center') {
     position = {
-      left: `${_x(x - width/2)}%`,
-      right: `${100 - _x(x + width/2)}%`,
+      left: `${_x(x - width / 2)}%`,
+      right: `${100 - _x(x + width / 2)}%`,
     }
   }
 
@@ -63,7 +74,7 @@ const Point = ({ x, y, children, align='left', verticalAlign='top', width }) => 
         style={{
           position: 'absolute',
           ...position,
-          ...verticalPosition
+          ...verticalPosition,
         }}
       >
         {children}

--- a/src/point.js
+++ b/src/point.js
@@ -1,8 +1,53 @@
 import React from 'react'
 import { useChart } from './chart'
 
-const Point = ({ x, y, children }) => {
+const Point = ({ x, y, children, align='left', verticalAlign='top', width }) => {
   const { x: _x, y: _y, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
+
+  let position, verticalPosition
+
+  if (!['left', 'right', 'center'].includes(align)) {
+    throw new Error(`'${align}' is not a recognized alignment, must be left, right, or center`)
+  }
+
+  if (!['top', 'bottom'].includes(verticalAlign)) {
+    throw new Error(`'${verticalAlign}' is not a recognized vertical alignment, must be top or bottom`)
+  }
+
+  if (align === 'center' && !width) {
+    throw new Error(`center alignment requires specifying a width`)
+  }
+
+  if (align === 'left') {
+    position = {
+      left: `${_x(x)}%`,
+    }
+  }
+
+  if (align === 'center') {
+    position = {
+      left: `${_x(x - width/2)}%`,
+      right: `${100 - _x(x + width/2)}%`,
+    }
+  }
+
+  if (align === 'right') {
+    position = {
+      right: `${100 - _x(x)}%`,
+    }
+  }
+
+  if (verticalAlign === 'top') {
+    verticalPosition = {
+      top: `${_y(y)}%`,
+    }
+  }
+
+  if (verticalAlign === 'bottom') {
+    verticalPosition = {
+      bottom: `${100 - _y(y)}%`,
+    }
+  }
 
   return (
     <div
@@ -17,8 +62,8 @@ const Point = ({ x, y, children }) => {
       <div
         style={{
           position: 'absolute',
-          top: `${_y(y)}%`,
-          left: `${_x(x)}%`,
+          ...position,
+          ...verticalPosition
         }}
       >
         {children}

--- a/src/point.js
+++ b/src/point.js
@@ -8,10 +8,13 @@ const Point = ({
   align = 'left',
   verticalAlign = 'top',
   width,
+  height,
 }) => {
   const { x: _x, y: _y, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
 
-  let position, verticalPosition
+  let position,
+    verticalPosition,
+    flexStyles = {}
 
   if (!['left', 'right', 'center'].includes(align)) {
     throw new Error(
@@ -19,7 +22,7 @@ const Point = ({
     )
   }
 
-  if (!['top', 'bottom'].includes(verticalAlign)) {
+  if (!['top', 'middle', 'bottom'].includes(verticalAlign)) {
     throw new Error(
       `'${verticalAlign}' is not a recognized vertical alignment, must be top or bottom`
     )
@@ -27,6 +30,10 @@ const Point = ({
 
   if (align === 'center' && !width) {
     throw new Error(`center alignment requires specifying a width`)
+  }
+
+  if (verticalAlign === 'middle' && !height) {
+    throw new Error(`middle vertical alignment requires specifying a height`)
   }
 
   if (align === 'left') {
@@ -54,6 +61,19 @@ const Point = ({
     }
   }
 
+  if (verticalAlign === 'middle') {
+    verticalPosition = {
+      top: `${_y(y + height / 2)}%`,
+      bottom: `${100 - _y(y - height / 2)}%`,
+    }
+    flexStyles = {
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignContent: 'center',
+    }
+  }
+
   if (verticalAlign === 'bottom') {
     verticalPosition = {
       bottom: `${100 - _y(y)}%`,
@@ -75,6 +95,7 @@ const Point = ({
           position: 'absolute',
           ...position,
           ...verticalPosition,
+          ...flexStyles,
         }}
       >
         {children}


### PR DESCRIPTION
This PR adds a couple options for label alignment. The specific use cases that motivated this were wanting to center a label on an x position, and wanting to align vertically to the bottom rather than the top (to preserve relationships while changing font sizes).

Not wedded to the API or implementation here! But adding this functionality is important.

To see it in action, In the following example rendered at two widths:
<img width="725" alt="CleanShot 2022-01-18 at 00 11 29@2x" src="https://user-images.githubusercontent.com/3387500/149896790-dd67eeca-dbb5-40f3-a930-f51dff326de9.png">
<img width="511" alt="CleanShot 2022-01-18 at 00 11 41@2x" src="https://user-images.githubusercontent.com/3387500/149896807-c4736e40-05b8-47a6-ab51-c8e2129a0740.png">

The +1 is rendered as

```
<Label x={0.5} y={1.1} width={1} align='center'>
  +1
</Label>
```

which ensures the label is centered at x=0.5. Similar for the other numbers.

As an example of vertical alignment, the label `2 TON YEARS` is also created using `verticalAlign='bottom'` to ensure that its bottom is at the same point regardless of the change in font size.

Two things up for discussion
- should we also implement `verticalAlign='center'`?
- should `align='center'` require a width?