### PR TITLE
bump widescreen font size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/charts",
-  "version": "2.5.0",
+  "version": "2.6.0-develop.0",
   "description": "themeable reusable responsive web charts",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/charts",
-  "version": "2.6.0-develop.0",
+  "version": "2.6.0-develop.2",
   "description": "themeable reusable responsive web charts",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/src/axis-label.js
+++ b/src/axis-label.js
@@ -58,7 +58,7 @@ const AxisLabel = ({
         <Box
           sx={{
             position: 'absolute',
-            bottom: `0`,
+            bottom: [`0px`, `0px`, `0px`, `-3px`],
             left: `${apl + pl + (align === 'right' ? 2 : 0)}px`,
             width: `calc(100% - ${apl + pl + pr + apr}px)`,
             textAlign: align,

--- a/src/axis-label.js
+++ b/src/axis-label.js
@@ -6,7 +6,7 @@ import Arrow from './arrow'
 const styles = {
   label: {
     position: 'absolute',
-    fontSize: [0],
+    fontSize: [0, 0, 0, 1],
     fontFamily: 'mono',
     letterSpacing: 'mono',
     color: 'primary',

--- a/src/axis-label.js
+++ b/src/axis-label.js
@@ -58,7 +58,7 @@ const AxisLabel = ({
         <Box
           sx={{
             position: 'absolute',
-            bottom: [`0px`, `0px`, `0px`, `-3px`],
+            bottom: [`0px`, `0px`, `0px`, `-4px`],
             left: `${apl + pl + (align === 'right' ? 2 : 0)}px`,
             width: `calc(100% - ${apl + pl + pr + apr}px)`,
             textAlign: align,

--- a/src/label.js
+++ b/src/label.js
@@ -17,7 +17,7 @@ const Label = ({ x, y, children, align, verticalAlign, width, height, sx }) => {
           fontFamily: 'mono',
           letterSpacing: 'mono',
           textTransform: 'uppercase',
-          fontSize: [0],
+          fontSize: [0, 0, 0, 1],
           color: 'secondary',
           textAlign: align,
           ...sx,

--- a/src/tick-labels.js
+++ b/src/tick-labels.js
@@ -6,7 +6,7 @@ import getTicks from './utils/get-ticks'
 const styles = {
   tick: {
     position: 'absolute',
-    fontSize: [0],
+    fontSize: [0, 0, 0, 1],
     fontFamily: 'mono',
     letterSpacing: 'mono',
     color: 'secondary',

--- a/src/tick-labels.js
+++ b/src/tick-labels.js
@@ -24,8 +24,19 @@ const VerticalTickLabels = ({
   sx,
 }) => {
   let position
-  if (top) position = { bottom: `${padding}px` }
-  if (bottom) position = { top: `${padding}px` }
+  if (top)
+    position = {
+      bottom: [
+        `${padding}px`,
+        `${padding}px`,
+        `${padding}px`,
+        `${padding + 1}px`,
+      ],
+    }
+  if (bottom)
+    position = {
+      top: [`${padding}px`, `${padding}px`, `${padding}px`, `${padding + 1}px`],
+    }
   return values.map((d, i) => {
     return (
       <Box
@@ -64,7 +75,7 @@ const HorizontalTickLabels = ({
         key={d}
         sx={{
           ...styles.tick,
-          top: `${y(d)}%`,
+          top: [`${y(d)}%`, `${y(d)}%`, `${y(d)}%`, `calc(${y(d)}% + 1px)`],
           right: '0',
           transform: 'translateY(-50%)',
           ...position,

--- a/src/ticks.js
+++ b/src/ticks.js
@@ -6,10 +6,6 @@ import getTicks from './utils/get-ticks'
 const styles = {
   tick: {
     position: 'absolute',
-    fontSize: [1, 1, 1, 2],
-    fontFamily: 'mono',
-    letterSpacing: 'mono',
-    color: 'secondary',
   },
 }
 


### PR DESCRIPTION
Extremely simple PR with potential visual consequences. It was flagged in the context of our articles that the default font size for labels, ticks, and axis labels in our charts is just too small at widescreens (our fourth breakpoint). This is particularly apparent when seen alongside the increase in body font size that occurs at the same breakpoint. This PR simply changes the default to `[0, 0, 0, 1]` for these elements, which is a font scale we have used for related content types in other settings. It then does a couple other very minor tweaks to make sure vertical axis labels are vertically centered on the corresponding ticks. I also shifted the bottom axis label down slightly to create more space. I did not do the same for the left axis label because it would break grid alignment on the left, whereas we rarely rely on such precise alignment at the bottom (and in fact, currently, the bottom axis label does not precisely align to the bottom of the chart div, the way the left axis label aligns to the left edge).

I tested this on every graphic from the `Research` site and found consistently this was an improvement and introduced no errors. Possible there will be small issues elsewhere on our sites, but nothing jumps out as a concern to me right now.

Here are some examples of before/after:
<img width="700" alt="CleanShot 2022-01-30 at 16 13 29@2x" src="https://user-images.githubusercontent.com/3387500/151723936-7b88e5c7-735a-4691-b95d-e1ea286324e1.png">
<img width="700" alt="CleanShot 2022-01-30 at 16 13 22@2x" src="https://user-images.githubusercontent.com/3387500/151723941-1257cf3c-d48c-43d0-9490-fedc6bcfc70a.png">



<img width="707" alt="CleanShot 2022-01-30 at 16 08 26@2x" src="https://user-images.githubusercontent.com/3387500/151723861-77661430-e253-4d41-985e-49593e954909.png">
<img width="707" alt="CleanShot 2022-01-30 at 16 08 15@2x" src="https://user-images.githubusercontent.com/3387500/151723866-f05c91cf-0124-4238-b3e0-f50f52b45179.png">


