### PR TITLE
Support responsive padding props

### DIFF
--- a/src/axis-label.js
+++ b/src/axis-label.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box, Flex } from 'theme-ui'
-import { useChart } from './chart'
 import Arrow from './arrow'
+import useResponsiveStyles from './utils/use-responsive-styles'
 
 const styles = {
   label: {
@@ -26,8 +26,14 @@ const AxisLabel = ({
   arrow = true,
   align = 'right',
 }) => {
-  const { x, y, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
-
+  const bottomSx = useResponsiveStyles(({ apl, pl, pr, apr }) => ({
+    left: `${apl + pl + (align === 'right' ? 2 : 0)}px`,
+    width: `calc(100% - ${apl + pl + pr + apr}px)`,
+  }))
+  const leftSx = useResponsiveStyles(({ apb, pb, apt, pt }) => ({
+    bottom: `${apb + pb + (align === 'right' ? 2 : 0)}px`,
+    height: `calc(100% - ${apt + pt + pb + apb}px)`,
+  }))
   const alignToFlexVertical = {
     left: 'flex-end',
     right: 'flex-start',
@@ -59,9 +65,8 @@ const AxisLabel = ({
           sx={{
             position: 'absolute',
             bottom: [`0px`, `0px`, `0px`, `-4px`],
-            left: `${apl + pl + (align === 'right' ? 2 : 0)}px`,
-            width: `calc(100% - ${apl + pl + pr + apr}px)`,
             textAlign: align,
+            ...bottomSx,
             ...styles.label,
             ...sx,
           }}
@@ -95,9 +100,8 @@ const AxisLabel = ({
           sx={{
             position: 'absolute',
             left: '-3px',
-            bottom: `${apb + pb + (align === 'right' ? 2 : 0)}px`,
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
             textAlign: align,
+            ...leftSx,
             ...styles.label,
             ...sx,
           }}

--- a/src/axis-label.js
+++ b/src/axis-label.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box, Flex } from 'theme-ui'
 import Arrow from './arrow'
-import useResponsiveStyles from './utils/use-responsive-styles'
+import useChartPadding from './utils/use-chart-padding'
 
 const styles = {
   label: {
@@ -26,11 +26,11 @@ const AxisLabel = ({
   arrow = true,
   align = 'right',
 }) => {
-  const bottomSx = useResponsiveStyles(({ apl, pl, pr, apr }) => ({
+  const bottomSx = useChartPadding(({ apl, pl, pr, apr }) => ({
     left: `${apl + pl + (align === 'right' ? 2 : 0)}px`,
     width: `calc(100% - ${apl + pl + pr + apr}px)`,
   }))
-  const leftSx = useResponsiveStyles(({ apb, pb, apt, pt }) => ({
+  const leftSx = useChartPadding(({ apb, pb, apt, pt }) => ({
     bottom: `${apb + pb + (align === 'right' ? 2 : 0)}px`,
     height: `calc(100% - ${apt + pt + pb + apb}px)`,
   }))

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box } from 'theme-ui'
-import { useChart } from './chart'
+import useResponsiveStyles from './utils/use-responsive-styles'
 
 const styles = {
   axis: {
@@ -12,7 +12,26 @@ const styles = {
 }
 
 const Axis = ({ left, right, top, bottom, sx }) => {
-  const { x, y, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
+  const leftSx = useResponsiveStyles(({ apt, pt, pb, apb, pl }) => ({
+    height: `calc(100% - ${apt + pt + pb + apb}px)`,
+    left: `${pl}px`,
+    top: `${apt + pt}px`,
+  }))
+  const rightSx = useResponsiveStyles(({ apt, pt, pb, apb, pr }) => ({
+    height: `calc(100% - ${apt + pt + pb + apb}px)`,
+    right: `${pr}px`,
+    top: `${apt + pt}px`,
+  }))
+  const bottomSx = useResponsiveStyles(({ apl, pl, pb, apr, pr }) => ({
+    width: `calc(100% - ${apl + pl + pr + apr}px)`,
+    bottom: `${pb - 1}px`,
+    left: `${apl + pl}px`,
+  }))
+  const topSx = useResponsiveStyles(({ apl, pl, pr, apr, pt }) => ({
+    width: `calc(100% - ${apl + pl + pr + apr}px)`,
+    top: `${pt}px`,
+    left: `${apl + pl}px`,
+  }))
 
   return (
     <>
@@ -21,10 +40,8 @@ const Axis = ({ left, right, top, bottom, sx }) => {
           sx={{
             ...styles.axis,
             borderRightWidth: '1px',
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
-            left: `${pl}px`,
-            top: `${apt + pt}px`,
             width: '1px',
+            ...leftSx,
             ...sx,
           }}
         />
@@ -34,10 +51,8 @@ const Axis = ({ left, right, top, bottom, sx }) => {
           sx={{
             ...styles.axis,
             borderRightWidth: '1px',
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
-            right: `${pr}px`,
-            top: `${apt + pt}px`,
             width: '1px',
+            ...rightSx,
             ...sx,
           }}
         />
@@ -47,10 +62,8 @@ const Axis = ({ left, right, top, bottom, sx }) => {
           sx={{
             ...styles.axis,
             borderTopWidth: '1px',
-            width: `calc(100% - ${apl + pl + pr + apr}px)`,
-            bottom: `${pb - 1}px`,
-            left: `${apl + pl}px`,
             height: '1px',
+            ...bottomSx,
             ...sx,
           }}
         />
@@ -60,10 +73,8 @@ const Axis = ({ left, right, top, bottom, sx }) => {
           sx={{
             ...styles.axis,
             borderTopWidth: '1px',
-            width: `calc(100% - ${apl + pl + pr + apr}px)`,
-            top: `${pt}px`,
-            left: `${apl + pl}px`,
             height: '1px',
+            ...topSx,
             ...sx,
           }}
         />

--- a/src/axis.js
+++ b/src/axis.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box } from 'theme-ui'
-import useResponsiveStyles from './utils/use-responsive-styles'
+import useChartPadding from './utils/use-chart-padding'
 
 const styles = {
   axis: {
@@ -12,22 +12,22 @@ const styles = {
 }
 
 const Axis = ({ left, right, top, bottom, sx }) => {
-  const leftSx = useResponsiveStyles(({ apt, pt, pb, apb, pl }) => ({
+  const leftSx = useChartPadding(({ apt, pt, pb, apb, pl }) => ({
     height: `calc(100% - ${apt + pt + pb + apb}px)`,
     left: `${pl}px`,
     top: `${apt + pt}px`,
   }))
-  const rightSx = useResponsiveStyles(({ apt, pt, pb, apb, pr }) => ({
+  const rightSx = useChartPadding(({ apt, pt, pb, apb, pr }) => ({
     height: `calc(100% - ${apt + pt + pb + apb}px)`,
     right: `${pr}px`,
     top: `${apt + pt}px`,
   }))
-  const bottomSx = useResponsiveStyles(({ apl, pl, pb, apr, pr }) => ({
+  const bottomSx = useChartPadding(({ apl, pl, pb, apr, pr }) => ({
     width: `calc(100% - ${apl + pl + pr + apr}px)`,
     bottom: `${pb - 1}px`,
     left: `${apl + pl}px`,
   }))
-  const topSx = useResponsiveStyles(({ apl, pl, pr, apr, pt }) => ({
+  const topSx = useChartPadding(({ apl, pl, pr, apr, pt }) => ({
     width: `calc(100% - ${apl + pl + pr + apr}px)`,
     top: `${pt}px`,
     left: `${apl + pl}px`,

--- a/src/grid.js
+++ b/src/grid.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import { useChart } from './chart'
 import getTicks from './utils/get-ticks'
-import useResponsiveStyles from './utils/use-responsive-styles'
+import useChartPadding from './utils/use-chart-padding'
 
 const styles = {
   grid: {
@@ -50,7 +50,7 @@ const HorizontalGrid = ({ values, y, sx }) => {
 
 const Grid = ({ horizontal, vertical, count = 5, values, sx }) => {
   const { x, y, logx, logy } = useChart()
-  const verticalSx = useResponsiveStyles(
+  const verticalSx = useChartPadding(
     ({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
       height: `calc(100% - ${apt + pt + pb + apb}px)`,
       width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
@@ -58,7 +58,7 @@ const Grid = ({ horizontal, vertical, count = 5, values, sx }) => {
       top: `${apt + pt}px`,
     })
   )
-  const horizontalSx = useResponsiveStyles(
+  const horizontalSx = useChartPadding(
     ({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
       height: `calc(100% - ${apt + pt + pb + apb}px)`,
       width: `calc(100% - ${apl + pl + pr + apr}px)`,

--- a/src/grid.js
+++ b/src/grid.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import { useChart } from './chart'
 import getTicks from './utils/get-ticks'
+import useResponsiveStyles from './utils/use-responsive-styles'
 
 const styles = {
   grid: {
@@ -48,8 +49,23 @@ const HorizontalGrid = ({ values, y, sx }) => {
 }
 
 const Grid = ({ horizontal, vertical, count = 5, values, sx }) => {
-  const { x, y, logx, logy, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
-
+  const { x, y, logx, logy } = useChart()
+  const verticalSx = useResponsiveStyles(
+    ({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
+      height: `calc(100% - ${apt + pt + pb + apb}px)`,
+      width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
+      left: `${apl + pl}px`,
+      top: `${apt + pt}px`,
+    })
+  )
+  const horizontalSx = useResponsiveStyles(
+    ({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
+      height: `calc(100% - ${apt + pt + pb + apb}px)`,
+      width: `calc(100% - ${apl + pl + pr + apr}px)`,
+      left: `${apl + pl}px`,
+      top: `${apt + pt}px`,
+    })
+  )
   values = getTicks({ values, count, logx, logy, x, y })
 
   return (
@@ -58,10 +74,7 @@ const Grid = ({ horizontal, vertical, count = 5, values, sx }) => {
         <Box
           sx={{
             position: 'absolute',
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
-            width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
-            left: `${apl + pl}px`,
-            top: `${apt + pt}px`,
+            ...verticalSx,
           }}
         >
           <VerticalGrid values={values.vertical} x={x} sx={sx} />
@@ -71,10 +84,7 @@ const Grid = ({ horizontal, vertical, count = 5, values, sx }) => {
         <Box
           sx={{
             position: 'absolute',
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
-            width: `calc(100% - ${apl + pl + pr + apr}px)`,
-            left: `${apl + pl}px`,
-            top: `${apt + pt}px`,
+            ...horizontalSx,
           }}
         >
           <HorizontalGrid bottom values={values.horizontal} y={y} sx={sx} />

--- a/src/plot.js
+++ b/src/plot.js
@@ -3,16 +3,20 @@ import { Box } from 'theme-ui'
 import useResponsiveStyles from './utils/use-responsive-styles'
 
 const Plot = ({ children, sx, mode = 'svg', square = false }) => {
+  const responsiveSx = useResponsiveStyles(
+    ({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
+      height: `calc(100% - ${apt + pt + pb + apb}px)`,
+      width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
+      left: `${apl + pl}px`,
+      top: `${apt + pt}px`,
+    })
+  )
+
   return (
     <div
       style={{
+        ...responsiveSx,
         position: 'absolute',
-        ...useResponsiveStyles(({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
-          height: `calc(100% - ${apt + pt + pb + apb}px)`,
-          width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
-          left: `${apl + pl}px`,
-          top: `${apt + pt}px`,
-        })),
         transform: `translate(0.5px, 0.5px)`,
       }}
     >

--- a/src/plot.js
+++ b/src/plot.js
@@ -13,8 +13,8 @@ const Plot = ({ children, sx, mode = 'svg', square = false }) => {
   )
 
   return (
-    <div
-      style={{
+    <Box
+      sx={{
         ...responsiveSx,
         position: 'absolute',
         transform: `translate(0.5px, 0.5px)`,
@@ -35,7 +35,7 @@ const Plot = ({ children, sx, mode = 'svg', square = false }) => {
           {children}
         </Box>
       )}
-    </div>
+    </Box>
   )
 }
 

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,18 +1,18 @@
 import React from 'react'
 import { Box } from 'theme-ui'
-import { useChart } from './chart'
+import useResponsiveStyles from './utils/use-responsive-styles'
 
 const Plot = ({ children, sx, mode = 'svg', square = false }) => {
-  const { pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
-
   return (
     <div
       style={{
         position: 'absolute',
-        height: `calc(100% - ${apt + pt + pb + apb}px)`,
-        width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
-        left: `${apl + pl}px`,
-        top: `${apt + pt}px`,
+        ...useResponsiveStyles(({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
+          height: `calc(100% - ${apt + pt + pb + apb}px)`,
+          width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
+          left: `${apl + pl}px`,
+          top: `${apt + pt}px`,
+        })),
         transform: `translate(0.5px, 0.5px)`,
       }}
     >

--- a/src/plot.js
+++ b/src/plot.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Box } from 'theme-ui'
-import useResponsiveStyles from './utils/use-responsive-styles'
+import useChartPadding from './utils/use-chart-padding'
 
 const Plot = ({ children, sx, mode = 'svg', square = false }) => {
-  const responsiveSx = useResponsiveStyles(
+  const responsiveSx = useChartPadding(
     ({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
       height: `calc(100% - ${apt + pt + pb + apb}px)`,
       width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,

--- a/src/point.js
+++ b/src/point.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box } from 'theme-ui'
 import { useChart } from './chart'
-import useResponsiveStyles from './utils/use-responsive-styles'
+import useChartPadding from './utils/use-chart-padding'
 
 const Point = ({
   x,
@@ -13,7 +13,7 @@ const Point = ({
   height,
 }) => {
   const { x: _x, y: _y } = useChart()
-  const responsiveSx = useResponsiveStyles(
+  const responsiveSx = useChartPadding(
     ({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
       height: `calc(100% - ${apt + pt + pb + apb}px)`,
       width: `calc(100% - ${apl + pl + pr + apr}px)`,

--- a/src/point.js
+++ b/src/point.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Box } from 'theme-ui'
 import { useChart } from './chart'
 import useResponsiveStyles from './utils/use-responsive-styles'
 
@@ -90,14 +91,14 @@ const Point = ({
   }
 
   return (
-    <div
-      style={{
+    <Box
+      sx={{
         position: 'absolute',
         ...responsiveSx,
       }}
     >
-      <div
-        style={{
+      <Box
+        sx={{
           position: 'absolute',
           ...position,
           ...verticalPosition,
@@ -105,8 +106,8 @@ const Point = ({
         }}
       >
         {children}
-      </div>
-    </div>
+      </Box>
+    </Box>
   )
 }
 

--- a/src/point.js
+++ b/src/point.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useChart } from './chart'
+import useResponsiveStyles from './utils/use-responsive-styles'
 
 const Point = ({
   x,
@@ -10,7 +11,15 @@ const Point = ({
   width,
   height,
 }) => {
-  const { x: _x, y: _y, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
+  const { x: _x, y: _y } = useChart()
+  const responsiveSx = useResponsiveStyles(
+    ({ apt, pt, pb, apb, apl, pl, pr, apr }) => ({
+      height: `calc(100% - ${apt + pt + pb + apb}px)`,
+      width: `calc(100% - ${apl + pl + pr + apr}px)`,
+      left: `${apl + pl}px`,
+      top: `${apt + pt}px`,
+    })
+  )
 
   let position,
     verticalPosition,
@@ -84,10 +93,7 @@ const Point = ({
     <div
       style={{
         position: 'absolute',
-        height: `calc(100% - ${apt + pt + pb + apb}px)`,
-        width: `calc(100% - ${apl + pl + pr + apr}px)`,
-        left: `${apl + pl}px`,
-        top: `${apt + pt}px`,
+        ...responsiveSx,
       }}
     >
       <div

--- a/src/tick-labels.js
+++ b/src/tick-labels.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import { useChart } from './chart'
 import getTicks from './utils/get-ticks'
-import useResponsiveStyles from './utils/use-responsive-styles'
+import useChartPadding from './utils/use-chart-padding'
 
 const styles = {
   tick: {
@@ -102,23 +102,23 @@ const TickLabels = ({
   sx,
 }) => {
   const { x, y, logx, logy } = useChart()
-  const leftSx = useResponsiveStyles(({ apt, pt, pb, apb, pl }) => ({
+  const leftSx = useChartPadding(({ apt, pt, pb, apb, pl }) => ({
     top: `${apt + pt}px`,
     height: `calc(100% - ${apt + pt + pb + apb}px)`,
     width: `${pl}px`,
   }))
-  const rightSx = useResponsiveStyles(({ apt, pt, pb, apb, pr }) => ({
+  const rightSx = useChartPadding(({ apt, pt, pb, apb, pr }) => ({
     top: `${apt + pt}px`,
     height: `calc(100% - ${apt + pt + pb + apb}px)`,
     width: `${pr}px`,
     left: `calc(100% - ${pr}px)`,
   }))
-  const bottomSx = useResponsiveStyles(({ pb, apl, pl, pr, apr }) => ({
+  const bottomSx = useChartPadding(({ pb, apl, pl, pr, apr }) => ({
     height: `${pb}px`,
     width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
     left: `${apl + pl}px`,
   }))
-  const topSx = useResponsiveStyles(({ pt, apl, pl, pr, apr }) => ({
+  const topSx = useChartPadding(({ pt, apl, pl, pr, apr }) => ({
     height: `${pt}px`,
     width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
     left: `${apl + pl}px`,

--- a/src/tick-labels.js
+++ b/src/tick-labels.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import { useChart } from './chart'
 import getTicks from './utils/get-ticks'
+import useResponsiveStyles from './utils/use-responsive-styles'
 
 const styles = {
   tick: {
@@ -100,7 +101,28 @@ const TickLabels = ({
   padding = 8,
   sx,
 }) => {
-  const { x, y, logx, logy, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
+  const { x, y, logx, logy } = useChart()
+  const leftSx = useResponsiveStyles(({ apt, pt, pb, apb, pl }) => ({
+    top: `${apt + pt}px`,
+    height: `calc(100% - ${apt + pt + pb + apb}px)`,
+    width: `${pl}px`,
+  }))
+  const rightSx = useResponsiveStyles(({ apt, pt, pb, apb, pr }) => ({
+    top: `${apt + pt}px`,
+    height: `calc(100% - ${apt + pt + pb + apb}px)`,
+    width: `${pr}px`,
+    left: `calc(100% - ${pr}px)`,
+  }))
+  const bottomSx = useResponsiveStyles(({ pb, apl, pl, pr, apr }) => ({
+    height: `${pb}px`,
+    width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
+    left: `${apl + pl}px`,
+  }))
+  const topSx = useResponsiveStyles(({ pt, apl, pl, pr, apr }) => ({
+    height: `${pt}px`,
+    width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
+    left: `${apl + pl}px`,
+  }))
 
   const countx = count == null ? (logx ? 2 : 5) : count
   const county = count == null ? (logy ? 2 : 5) : count
@@ -136,9 +158,7 @@ const TickLabels = ({
         <Box
           sx={{
             position: 'absolute',
-            top: `${apt + pt}px`,
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
-            width: `${pl}px`,
+            ...leftSx,
             left: 0,
           }}
         >
@@ -156,10 +176,7 @@ const TickLabels = ({
         <Box
           sx={{
             position: 'absolute',
-            top: `${apt + pt}px`,
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
-            width: `${pr}px`,
-            left: `calc(100% - ${pr}px)`,
+            ...rightSx,
           }}
         >
           <HorizontalTickLabels
@@ -176,9 +193,7 @@ const TickLabels = ({
         <Box
           sx={{
             position: 'absolute',
-            height: `${pb}px`,
-            width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
-            left: `${apl + pl}px`,
+            ...bottomSx,
             bottom: '0px',
           }}
         >
@@ -196,9 +211,7 @@ const TickLabels = ({
         <Box
           sx={{
             position: 'absolute',
-            height: `${pt}px`,
-            width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
-            left: `${apl + pl}px`,
+            ...topSx,
             top: `1px`,
           }}
         >

--- a/src/ticks.js
+++ b/src/ticks.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import { useChart } from './chart'
 import getTicks from './utils/get-ticks'
+import useResponsiveStyles from './utils/use-responsive-styles'
 
 const styles = {
   tick: {
@@ -68,7 +69,31 @@ const Ticks = ({
   padding = 0,
   sx,
 }) => {
-  const { x, y, logx, logy, pl, pr, pt, pb, apl, apr, apt, apb } = useChart()
+  const { x, y, logx, logy } = useChart()
+
+  const leftSx = useResponsiveStyles(({ apt, pt, apt, pt, pb, apb, pl }) => ({
+    top: `${apt + pt}px`,
+    height: `calc(100% - ${apt + pt + pb + apb}px)`,
+    width: `${pl + 1}px`,
+  }))
+
+  const rightSx = useResponsiveStyles(({ apt, pt, pb, apb, pr }) => ({
+    top: `${apt + pt}px`,
+    height: `calc(100% - ${apt + pt + pb + apb}px)`,
+    width: `${pr}px`,
+    left: `calc(100% - ${pr + 1}px)`,
+  }))
+
+  const bottomSx = useResponsiveStyles(({ pb, apl, pl, pr, apr }) => ({
+    height: `${pb}px`,
+    width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
+    left: `${apl + pl}px`,
+  }))
+  const topSx = useResponsiveStyles(({ pt, apl, pl, pr, apr }) => ({
+    height: `${pt}px`,
+    width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
+    left: `${apl + pl}px`,
+  }))
 
   values = getTicks({ values, count, logx, logy, x, y })
 
@@ -77,10 +102,8 @@ const Ticks = ({
       {left && (
         <Box
           sx={{
+            ...leftSx,
             position: 'absolute',
-            top: `${apt + pt}px`,
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
-            width: `${pl + 1}px`,
             left: 0,
           }}
         >
@@ -97,11 +120,8 @@ const Ticks = ({
       {right && (
         <Box
           sx={{
+            ...rightSx,
             position: 'absolute',
-            top: `${apt + pt}px`,
-            height: `calc(100% - ${apt + pt + pb + apb}px)`,
-            width: `${pr}px`,
-            left: `calc(100% - ${pr + 1}px)`,
           }}
         >
           <HorizontalTicks
@@ -117,10 +137,8 @@ const Ticks = ({
       {bottom && (
         <Box
           sx={{
+            ...bottomSx,
             position: 'absolute',
-            height: `${pb}px`,
-            width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
-            left: `${apl + pl}px`,
             bottom: '0px',
           }}
         >
@@ -137,10 +155,8 @@ const Ticks = ({
       {top && (
         <Box
           sx={{
+            ...topSx,
             position: 'absolute',
-            height: `${pt}px`,
-            width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
-            left: `${apl + pl}px`,
             top: `1px`,
           }}
         >

--- a/src/ticks.js
+++ b/src/ticks.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box } from 'theme-ui'
 import { useChart } from './chart'
 import getTicks from './utils/get-ticks'
-import useResponsiveStyles from './utils/use-responsive-styles'
+import useChartPadding from './utils/use-chart-padding'
 
 const styles = {
   tick: {
@@ -71,25 +71,25 @@ const Ticks = ({
 }) => {
   const { x, y, logx, logy } = useChart()
 
-  const leftSx = useResponsiveStyles(({ apt, pt, pb, apb, pl }) => ({
+  const leftSx = useChartPadding(({ apt, pt, pb, apb, pl }) => ({
     top: `${apt + pt}px`,
     height: `calc(100% - ${apt + pt + pb + apb}px)`,
     width: `${pl + 1}px`,
   }))
 
-  const rightSx = useResponsiveStyles(({ apt, pt, pb, apb, pr }) => ({
+  const rightSx = useChartPadding(({ apt, pt, pb, apb, pr }) => ({
     top: `${apt + pt}px`,
     height: `calc(100% - ${apt + pt + pb + apb}px)`,
     width: `${pr}px`,
     left: `calc(100% - ${pr + 1}px)`,
   }))
 
-  const bottomSx = useResponsiveStyles(({ pb, apl, pl, pr, apr }) => ({
+  const bottomSx = useChartPadding(({ pb, apl, pl, pr, apr }) => ({
     height: `${pb}px`,
     width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
     left: `${apl + pl}px`,
   }))
-  const topSx = useResponsiveStyles(({ pt, apl, pl, pr, apr }) => ({
+  const topSx = useChartPadding(({ pt, apl, pl, pr, apr }) => ({
     height: `${pt}px`,
     width: `calc(100% - ${apl + pl + pr + apr + 1}px)`,
     left: `${apl + pl}px`,

--- a/src/ticks.js
+++ b/src/ticks.js
@@ -71,7 +71,7 @@ const Ticks = ({
 }) => {
   const { x, y, logx, logy } = useChart()
 
-  const leftSx = useResponsiveStyles(({ apt, pt, apt, pt, pb, apb, pl }) => ({
+  const leftSx = useResponsiveStyles(({ apt, pt, pb, apb, pl }) => ({
     top: `${apt + pt}px`,
     height: `calc(100% - ${apt + pt + pb + apb}px)`,
     width: `${pl + 1}px`,

--- a/src/utils/use-chart-padding.js
+++ b/src/utils/use-chart-padding.js
@@ -11,7 +11,9 @@ const getChartPadding = (functionalSx, rawValues) => {
         if (rawValue.length === 4) {
           arrayValue = rawValue
         } else {
-          throw new Error('can only handle 4 breakpoints')
+          arrayValue = new Array(4)
+            .fill(null)
+            .map((_, i) => rawValue[i] ?? rawValue[rawValue.length - 1])
         }
       } else {
         arrayValue = new Array(4).fill(rawValue)

--- a/src/utils/use-chart-padding.js
+++ b/src/utils/use-chart-padding.js
@@ -2,7 +2,7 @@ import { useChart } from '../chart'
 
 const KEYS = ['pl', 'pr', 'pt', 'pb', 'apl', 'apr', 'apt', 'apb']
 
-const getResponsiveStyles = (functionalSx, rawValues) => {
+const getChartPadding = (functionalSx, rawValues) => {
   const breakpointValues = KEYS.reduce(
     (accum, key) => {
       const rawValue = rawValues[key]
@@ -25,17 +25,22 @@ const getResponsiveStyles = (functionalSx, rawValues) => {
     [{}, {}, {}, {}]
   )
 
-  return Object.keys(functionalSx).reduce((accum, key) => {
-    const f = functionalSx[key]
-    accum[key] = breakpointValues.map((values) => f(values))
+  const sxKeys = Object.keys(functionalSx({}))
+
+  return breakpointValues.reduce((accum, values, i) => {
+    const result = functionalSx(values)
+    sxKeys.map((key) => {
+      accum[key] ||= []
+      accum[key].push(result[key])
+    })
     return accum
   }, {})
 }
 
-const useResponsiveStyles = (functionalSx) => {
+const useChartPadding = (functionalSx) => {
   const chart = useChart()
 
-  return getResponsiveStyles(functionalSx, chart)
+  return getChartPadding(functionalSx, chart)
 }
 
-export default useResponsiveStyles
+export default useChartPadding

--- a/src/utils/use-chart-padding.js
+++ b/src/utils/use-chart-padding.js
@@ -3,40 +3,44 @@ import { useChart } from '../chart'
 const KEYS = ['pl', 'pr', 'pt', 'pb', 'apl', 'apr', 'apt', 'apb']
 
 const getChartPadding = (functionalSx, rawValues) => {
-  const breakpointValues = KEYS.reduce(
-    (accum, key) => {
-      const rawValue = rawValues[key]
-      let arrayValue
-      if (Array.isArray(rawValue)) {
-        if (rawValue.length === 4) {
-          arrayValue = rawValue
+  if (KEYS.some((key) => Array.isArray(rawValues[key]))) {
+    const breakpointValues = KEYS.reduce(
+      (accum, key) => {
+        const rawValue = rawValues[key]
+        let arrayValue
+        if (Array.isArray(rawValue)) {
+          if (rawValue.length === 4) {
+            arrayValue = rawValue
+          } else {
+            arrayValue = new Array(4)
+              .fill(null)
+              .map((_, i) => rawValue[i] ?? rawValue[rawValue.length - 1])
+          }
         } else {
-          arrayValue = new Array(4)
-            .fill(null)
-            .map((_, i) => rawValue[i] ?? rawValue[rawValue.length - 1])
+          arrayValue = new Array(4).fill(rawValue)
         }
-      } else {
-        arrayValue = new Array(4).fill(rawValue)
-      }
-      arrayValue.forEach((value, i) => {
-        accum[i][key] = value
+        arrayValue.forEach((value, i) => {
+          accum[i][key] = value
+        })
+
+        return accum
+      },
+      [{}, {}, {}, {}]
+    )
+
+    const sxKeys = Object.keys(functionalSx({}))
+
+    return breakpointValues.reduce((accum, values, i) => {
+      const result = functionalSx(values)
+      sxKeys.map((key) => {
+        accum[key] ||= []
+        accum[key].push(result[key])
       })
-
       return accum
-    },
-    [{}, {}, {}, {}]
-  )
-
-  const sxKeys = Object.keys(functionalSx({}))
-
-  return breakpointValues.reduce((accum, values, i) => {
-    const result = functionalSx(values)
-    sxKeys.map((key) => {
-      accum[key] ||= []
-      accum[key].push(result[key])
-    })
-    return accum
-  }, {})
+    }, {})
+  } else {
+    return functionalSx(rawValues)
+  }
 }
 
 const useChartPadding = (functionalSx) => {

--- a/src/utils/use-responsive-styles.js
+++ b/src/utils/use-responsive-styles.js
@@ -1,0 +1,41 @@
+import { useChart } from '../chart'
+
+const KEYS = ['pl', 'pr', 'pt', 'pb', 'apl', 'apr', 'apt', 'apb']
+
+const getResponsiveStyles = (functionalSx, rawValues) => {
+  const breakpointValues = KEYS.reduce(
+    (accum, key) => {
+      const rawValue = rawValues[key]
+      let arrayValue
+      if (Array.isArray(rawValue)) {
+        if (rawValue.length === 4) {
+          arrayValue = rawValue
+        } else {
+          throw new Error('can only handle 4 breakpoints')
+        }
+      } else {
+        arrayValue = new Array(4).fill(rawValue)
+      }
+      arrayValue.forEach((value, i) => {
+        accum[i][key] = value
+      })
+
+      return accum
+    },
+    [{}, {}, {}, {}]
+  )
+
+  return Object.keys(functionalSx).reduce((accum, key) => {
+    const f = functionalSx[key]
+    accum[key] = breakpointValues.map((values) => f(values))
+    return accum
+  }, {})
+}
+
+const useResponsiveStyles = (functionalSx) => {
+  const chart = useChart()
+
+  return getResponsiveStyles(functionalSx, chart)
+}
+
+export default useResponsiveStyles


### PR DESCRIPTION
Updates chart elements to handle `padding` and `axisPadding` props with responsive array values.

This allows padding to be customized across breakpoints. For example in [`ParamChart`](https://github.com/carbonplan/research/blob/aedd9be973b13f80426363efbfdf53c8f66c49c3/tools/dac-calculator/components/charts/param-chart.js), we could fix the overflow at large screen sizes by specifying a larger `pr` only at the largest breakpoint:
```jsx
padding={{
  left: 0,
  right: [0, 0, 0, 3],
  top: 0,
  bottom: 22,
}}
```
Within chart elements, we handle these responsive padding values by generating styles using the `useChartPadding` utility hook.
```js
useChartPadding(({ apl, pl, pr, apr }) => ({
  left: `${apl + pl + (align === 'right' ? 2 : 0)}px`,
  width: `calc(100% - ${apl + pl + pr + apr}px)`,
}))
// could return {
//   left: ['0px', '0px', '10px', '10px'],
//   width: ['calc(100% - 0px)', 'calc(100% - 0px)', 'calc(100% - 20px)', 'calc(100% - 20px)'],
// }
```