### PR TITLE
fix scatter plots in safari

### DIFF
--- a/src/scatter.js
+++ b/src/scatter.js
@@ -15,14 +15,7 @@ const Scatter = ({
   x = x || ((d) => d[0])
   y = y || ((d) => d[1])
 
-  const path = data
-    .map(
-      (d, i) =>
-        `M${_x(x(d))} ${_y(y(d))} A0 0 0 0 1 ${_x(x(d)) + 0.0001} ${
-          _y(y(d)) + 0.0001
-        }`
-    )
-    .join(' ')
+  const path = data.map((d) => `M${_x(x(d))},${_y(y(d))} l0.01,0.01`).join(' ')
 
   return (
     <Box


### PR DESCRIPTION
Our Scatter component drops some or all of the points in Safari (see here: https://carbonplan.org/research/stripe-2020-insights) 

This fix changes the path rendering from using arcs to using lines and appears to solve the issue in all browsers tested (safari, ff, chrome) 